### PR TITLE
Updated package.swift to support swift-tools-version:5.5. 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.5
 /**
  This file is part of the Reductio package.
  (c) Sergio Fernández <fdz.sergio@gmail.com>
@@ -9,5 +10,29 @@
 import PackageDescription
 
 let package = Package(
-  name: "Reductio"
+    name: "Reductio",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Reductio",
+            targets: ["Reductio"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Reductio",
+            dependencies: [],
+            path: "Source"
+        ),
+        .testTarget(
+            name: "ReductioTests",
+            dependencies: ["Reductio"],
+            path: "Tests"
+        ),
+    ]
 )

--- a/Source/TextRank.swift
+++ b/Source/TextRank.swift
@@ -46,7 +46,7 @@ internal final class TextRank<T: Hashable> {
     private func iteration(_ nodes: Node) -> Node {
         var vertex = Node()
         for (node, links) in graph {
-            let score: Float = links.reduce(0.0) { $0 + nodes[$1] / outlinks[$1] * weights[$1, node] }
+            let score: Float = links.reduce(0.0) { $0 + nodes[$1]! / outlinks[$1]! * weights[$1, node] }
             vertex[node] = (1-damping/nodes.count) + damping * score
         }
         return vertex
@@ -57,7 +57,7 @@ internal final class TextRank<T: Hashable> {
         if current == nodes { return true }
 
         let total: Float = nodes.reduce(0.0) {
-            return $0 + pow(current[$1.0] - $1.1, 2)
+            return $0 + pow(current[$1.0]! - $1.1, 2)
         }
         return sqrtf(total/current.count) < convergence
     }


### PR DESCRIPTION
Changed Package.swift
This resolves the issue complaining about the missing swift-tools-version line. Without it package is incompatible for Swift 4,5.

Small bug fixes in iteration convergence to unwrap optionals.