### PR TITLE
Fix sentence parser for empty strings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.5
 /**
  This file is part of the Reductio package.
  (c) Sergio Fernández <fdz.sergio@gmail.com>
@@ -5,9 +6,22 @@
  For the full copyright and license information, please view the LICENSE
  file that was distributed with this source code.
  */
-
 import PackageDescription
 
 let package = Package(
-  name: "Reductio"
+    name: "Reductio",
+    platforms: [
+        .iOS(.v8),
+        .macOS(.v10_10),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        .library(name: "Reductio", targets: ["Reductio"])
+    ],
+    targets: [
+        .target(name: "Reductio", path: "Source"),
+        .testTarget(name: "ReductioTests", path: "Tests")
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/Source/Sentence.swift
+++ b/Source/Sentence.swift
@@ -41,11 +41,15 @@ internal extension String {
 
     var sentences: [String] {
 
-        var sentences = [String]()
-        let range = self.range(of: self)
+        guard !self.isEmpty else { return [] }
 
-        self.enumerateSubstrings(in: range!, options: .bySentences) { (substring, _, _, _) in
-            sentences.append(substring!)
+        var sentences = [String]()
+        let range = startIndex..<endIndex
+
+        self.enumerateSubstrings(in: range, options: .bySentences) { (substring, _, _, _) in
+            if let substring = substring {
+                sentences.append(substring)
+            }
         }
         return sentences
     }

--- a/Tests/ReductioTests.swift
+++ b/Tests/ReductioTests.swift
@@ -28,6 +28,10 @@ final class ReductioTests: XCTestCase {
         XCTAssert("".keywords.isEmpty)
     }
 
+    func testEmptyTextSummarize() {
+        XCTAssert("".summarize.isEmpty)
+    }
+
     func testTextContainsKeywords() {
 
         XCTAssert(keywords.contains("oculus"))


### PR DESCRIPTION
## Summary
- avoid crashing when computing sentences for an empty string
- expose Reductio as an SPM package
- add unit test for empty summarize calls

## Testing
- `swift test` *(fails: swift-corelibs-foundation lacks required APIs)*